### PR TITLE
Fix legacy DB Path on iOS

### DIFF
--- a/KillTeam/Services/DBUpdater.cs
+++ b/KillTeam/Services/DBUpdater.cs
@@ -62,6 +62,7 @@ namespace KillTeam.Services
         {
             if (OldUdb == null && File.Exists(KTLegacyContext.DBPath))
             {
+                Console.WriteLine("Using Legacy Context");
                 return new KTLegacyContext();
             }
 
@@ -89,9 +90,10 @@ namespace KillTeam.Services
                 newUdb.ImportRules(Provider);
                 if (backup != null)
                 {
-                    Log($"Backing up old Database");
+                    string legacy = (backup is KTLegacyContext ? "legacy " : "");
+                    Log($"Backing up old {legacy}Database");
                     var replacements = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(Provider.GetReplacementsJSON());
-                    Log($"Applying backup to new Database");
+                    Log($"Applying {legacy}backup to new Database");
                     Sauvegarde.SetSerializedData(
                         newUdb,
                         Sauvegarde.GetSerializedData(backup),

--- a/KillTeam/Services/KTContext.cs
+++ b/KillTeam/Services/KTContext.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.AppCenter.Crashes;
+using Xamarin.Forms;
 
 namespace KillTeam.Services
 {
@@ -34,6 +35,22 @@ namespace KillTeam.Services
                     typeof(KTContext).Assembly,
                     RulesProviders.ManifestRulesProvider.MANIFEST_RULES_PREFIX);
             }
+        }
+
+        public static bool ShouldShowLegacyImportModal()
+        {
+            if (Device.RuntimePlatform != Device.iOS)
+            {
+                return false;
+            }
+
+            if (!File.Exists(DBPath) || !File.Exists(KTLegacyContext.DBPath))
+            {
+                return false;
+            }
+
+            var oldDB = new KTUserContext(DBPath);
+            return (oldDB.GetCurrentVersion().RulesVersion == "1.1.1-c3a06fceb2f395c3f188ecd9bbfcd86781b8face5e29032b969b3a97b72c84c7");
         }
 
     }

--- a/KillTeam/Services/KTLegacyContext.cs
+++ b/KillTeam/Services/KTLegacyContext.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.AppCenter.Crashes;
+using Xamarin.Forms;
 
 namespace KillTeam.Services
 {
@@ -24,7 +25,18 @@ namespace KillTeam.Services
             }
         }
 
-        private const string DBName = "KTDatabase.db";
+        private static string DBName {
+            get {
+                switch (Device.RuntimePlatform)
+                {
+                    case Device.iOS:
+                        return "KTDatabaseProd.db";
+                    case Device.Android:
+                    default:
+                        return "KTDatabase.db";
+                }
+            }
+        }
 
         public static string DBPath
         {

--- a/KillTeam/ViewModels/DatabaseLoadViewModel.cs
+++ b/KillTeam/ViewModels/DatabaseLoadViewModel.cs
@@ -15,7 +15,10 @@ namespace KillTeam.ViewModels
 
         public DatabaseLoadViewModel()
         {
-            // TODO
+        }
+
+        public void StartUpdate()
+        {
             ThreadPool.QueueUserWorkItem(_o => this.UpdateDB());
         }
 

--- a/KillTeam/Views/DatabaseLoadPage.xaml.cs
+++ b/KillTeam/Views/DatabaseLoadPage.xaml.cs
@@ -3,6 +3,7 @@ using KillTeam.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -31,12 +32,23 @@ namespace KillTeam.Views
             {
                 if (showModal)
                 {
-                    bool result = await Application.Current.MainPage.DisplayAlert(
-                        "Which Version?",
-                        "There was a bug in v2.1.4 that lost teams before that. Would you like to restore your teams from before, or keep the new ones you made in 2.1.4?",
-                        "Use Old Teams",
-                        "Keep Teams from v2.1.4"
-                    );
+                    var title = Equals(TranslateExtension.Ci, CultureInfo.GetCultureInfo("fr"))
+                        ? "Quelle version ?"
+                        : "Which Version?";
+
+                    var message = Equals(TranslateExtension.Ci, CultureInfo.GetCultureInfo("fr"))
+                        ? "La mise à jour 2.1.4 a pu provoqué la suppression de vos équipes. Souhaitez-vous les récupérer, ou utiliser celle que vous avez créé dans la version 2.1.4 ?"
+                        : "There was a bug in v2.1.4 that lost teams before that. Would you like to restore your teams from before, or keep the new ones you made in 2.1.4?";
+
+                    var accept = Equals(TranslateExtension.Ci, CultureInfo.GetCultureInfo("fr"))
+                        ? "Récupérer mes anciennes équipes"
+                        : "Use Old Teams";
+
+                    var cancel = Equals(TranslateExtension.Ci, CultureInfo.GetCultureInfo("fr"))
+                        ? "Garder mes équipes v2.1.4"
+                        : "Keep Teams from v2.1.4";
+
+                    bool result = await Application.Current.MainPage.DisplayAlert(title, message, accept, cancel);
                     if (result)
                     {
                         // deleting the old user db before we start the DBUpdater will cause it to fall back to the LegacyDB

--- a/KillTeam/Views/DatabaseLoadPage.xaml.cs
+++ b/KillTeam/Views/DatabaseLoadPage.xaml.cs
@@ -1,7 +1,9 @@
-﻿using KillTeam.ViewModels;
+﻿using KillTeam.Services;
+using KillTeam.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,5 +22,31 @@ namespace KillTeam.Views
 
             BindingContext = new DatabaseLoadViewModel();
         }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            bool showModal = KTContext.ShouldShowLegacyImportModal();
+            Device.BeginInvokeOnMainThread(async () =>
+            {
+                if (showModal)
+                {
+                    bool result = await Application.Current.MainPage.DisplayAlert(
+                        "Which Version?",
+                        "There was a bug in v2.1.4 that lost teams before that. Would you like to restore your teams from before, or keep the new ones you made in 2.1.4?",
+                        "Use Old Teams",
+                        "Keep Teams from v2.1.4"
+                    );
+                    if (result)
+                    {
+                        // deleting the old user db before we start the DBUpdater will cause it to fall back to the LegacyDB
+                        File.Delete(KTContext.DBPath);
+                    }
+                }
+
+                (BindingContext as DatabaseLoadViewModel).StartUpdate();
+            });
+        }
+
     }
 }


### PR DESCRIPTION
In the database refactor, we accidentally dropped the old path name for iOS, which was different than the android one for some reason. This fixes the legacy db path to match (looked a the old repo to confirm), and then adds a prompt for folks who upgrade to see if they want to restore their old teams, or keep the ones they made on 2.1.4. I'd love to merge instead, but that's a bit complicated.