### PR TITLE
Fixes #101 | CSM with Autocannon crashes the app

### DIFF
--- a/KillTeam/Models/Weapon.cs
+++ b/KillTeam/Models/Weapon.cs
@@ -104,7 +104,7 @@ namespace KillTeam.Models
 
             if (WeaponProfiles.Count > 0)
             {
-                ret = WeaponProfiles.First().WeaponType.Index - other.WeaponProfiles.First().WeaponType.Index;
+                ret = WeaponProfiles.First().WeaponType.Index - other.WeaponProfiles.First().WeaponType?.Index ?? Int32.MaxValue;
                 if (ret != 0) return ret;
 
                 return WeaponProfiles.First().ShotNumber.CompareTo(other.WeaponProfiles.First().ShotNumber);


### PR DESCRIPTION
Minor tweak to stop the app from crashing with certain weapons e.g. CSM Gunner with Autocannon