### PR TITLE
Adds QueryProcessor to separate queries from Controllers

### DIFF
--- a/KillTeam/Models/Team.cs
+++ b/KillTeam/Models/Team.cs
@@ -185,8 +185,8 @@ namespace KillTeam.Models
         {
             get
             {
-                int count = GetSelectedMembers().Count();
-                return Faction.Name + " - " + count + " " + (count <= 1 ? Properties.Resources.Membre : Properties.Resources.Membres);
+                var count = GetSelectedMembers().Count();
+                return $"{Faction.Name} - {count} {(count <= 1 ? Properties.Resources.Membre : Properties.Resources.Membres)}";
             }
         }
         

--- a/KillTeam/Models/Team.cs
+++ b/KillTeam/Models/Team.cs
@@ -179,16 +179,6 @@ namespace KillTeam.Models
                 return liste;
             }
         }
-
-        [JsonIgnore]
-        public string FactionNameAndMembersCount
-        {
-            get
-            {
-                var count = GetSelectedMembers().Count();
-                return $"{Faction.Name} - {count} {(count <= 1 ? Properties.Resources.Membre : Properties.Resources.Membres)}";
-            }
-        }
         
         #endregion Calculated Properties
 

--- a/KillTeam/Queries/AllTeamsQuery.cs
+++ b/KillTeam/Queries/AllTeamsQuery.cs
@@ -1,0 +1,7 @@
+namespace KillTeam.Queries
+{
+    public class AllTeamsQuery : IQuery
+    {
+        
+    }
+}

--- a/KillTeam/Queries/Handlers/AllTeamsQueryHandler.cs
+++ b/KillTeam/Queries/Handlers/AllTeamsQueryHandler.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using KillTeam.Services;
+using KillTeam.ViewModels;
+using Microsoft.EntityFrameworkCore;
+
+namespace KillTeam.Queries.Handlers
+{
+    public class AllTeamsQueryHandler : IQueryHandler<AllTeamsQuery, List<TeamsViewModel>>
+    {
+        public async Task<List<TeamsViewModel>> Execute(AllTeamsQuery query)
+        {
+            var teams = await KTContext.Db.Teams
+                .Include(e => e.Faction)
+                .Include(e => e.Members)
+                .AsNoTracking()
+                .OrderBy(post => post.Position)
+                .ToListAsync();
+
+            return teams
+                .Select(t => new TeamsViewModel(t.Id, t.Name, t.Cost, t.FactionNameAndMembersCount))
+                .ToList();
+        }
+    }
+}

--- a/KillTeam/Queries/Handlers/AllTeamsQueryHandler.cs
+++ b/KillTeam/Queries/Handlers/AllTeamsQueryHandler.cs
@@ -16,10 +16,26 @@ namespace KillTeam.Queries.Handlers
                 .Include(e => e.Members)
                 .AsNoTracking()
                 .OrderBy(post => post.Position)
+                .Select(t => new
+                {
+                    t.Id,
+                    t.Name,
+                    t.Members,
+                    t.Faction,
+                    t.Roster
+                })
                 .ToListAsync();
 
             return teams
-                .Select(t => new TeamsViewModel(t.Id, t.Name, t.Cost, t.FactionNameAndMembersCount))
+                .Select(t =>
+                {
+                    var selectedMembers = t.Members.Where(m => m.Selected || !t.Roster).ToList();
+                    var count = selectedMembers.Count();
+                    var cost = selectedMembers.Sum(m => m.Cost);
+                    var subtitle = $"{t.Faction.Name} - {count} {(count <= 1 ? Properties.Resources.Membre : Properties.Resources.Membres)}";
+                    
+                    return new TeamsViewModel(t.Id, t.Name, cost, subtitle);
+                })
                 .ToList();
         }
     }

--- a/KillTeam/Queries/Handlers/IQueryHandler.cs
+++ b/KillTeam/Queries/Handlers/IQueryHandler.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace KillTeam.Queries.Handlers
+{
+    public interface IQueryHandler<in TQuery, TResponse> where TQuery : IQuery
+    {
+        Task<TResponse> Execute(TQuery query);
+    }
+}

--- a/KillTeam/Queries/Handlers/IQueryProcessor.cs
+++ b/KillTeam/Queries/Handlers/IQueryProcessor.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace KillTeam.Queries.Handlers
+{
+    public interface IQueryProcessor
+    {
+        Task<TResult> Execute<TQuery, TResult>(TQuery query) where TQuery : IQuery;
+    }
+
+    public class QueryProcessor : IQueryProcessor
+    {
+        public static IQueryProcessor Instance() => _queryProcessor;
+
+        private static readonly IQueryProcessor _queryProcessor = new QueryProcessor();
+        
+        public async Task<TResult> Execute<TQuery, TResult>(TQuery query) where TQuery : IQuery
+        {
+            var handlerType =
+                Assembly
+                    .GetAssembly(typeof(TQuery))
+                    .DefinedTypes
+                    .FirstOrDefault(t => t.ImplementedInterfaces.Contains(typeof(IQueryHandler<TQuery, TResult>)));
+
+            if (handlerType is null)
+                throw new InvalidOperationException($"No query handler for Query {typeof(TQuery)} for result {typeof(TResult)}");
+
+            var handler = Activator.CreateInstance(handlerType) as IQueryHandler<TQuery, TResult>;
+
+            return await handler.Execute(query);
+        }
+    }
+}

--- a/KillTeam/Queries/IQuery.cs
+++ b/KillTeam/Queries/IQuery.cs
@@ -1,0 +1,7 @@
+namespace KillTeam.Queries
+{
+    public interface IQuery
+    {
+        
+    }
+}

--- a/KillTeam/Views/TeamsView.xaml.cs
+++ b/KillTeam/Views/TeamsView.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using KillTeam.Commands.Handlers;
 using KillTeam.Controllers;
+using KillTeam.Queries.Handlers;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using Xamarin.Forms.Xaml;
 
@@ -13,7 +14,11 @@ namespace KillTeam.Views
             InitializeComponent();
             On<Xamarin.Forms.PlatformConfiguration.iOS>().SetUseSafeArea(true);
 
-            BindingContext = new TeamsController(ToolbarItems, new DeleteTeamCommandHandler(), new ReorderTeamsCommandHandler());
+            BindingContext = new TeamsController(
+                ToolbarItems, 
+                new DeleteTeamCommandHandler(), 
+                new ReorderTeamsCommandHandler(),
+                QueryProcessor.Instance());
         }
 
         protected override async void OnAppearing()


### PR DESCRIPTION
- Adds IQueryProcessor and QueryProcessor to handle executing of all queries
- Adds GetAllTeamsQuery and Handler to fetch Teams for the TeamsView

By separating out the queries from the controllers we should be able to start writing unit tests over the controllers and passing in a dummy query processor that we can check to see if a particular query was run when we needed it without having to run the query and set-up a KTContext etc.

I've used a simple static singleton to retrieve the QueryProcessor each time. Ideally we'd move this to an IoC container eventually. For now it serves it's possible.

Next step is to do something similar with the CommandHandlers so we don't need to pass in each one every time.