### PR TITLE
Makes equipment combos more efficient

### DIFF
--- a/KillTeam/Models/PossibleSwap.cs
+++ b/KillTeam/Models/PossibleSwap.cs
@@ -117,14 +117,13 @@ namespace KillTeam.Models
                     configuration.CostOverrides = costOverrides;
                 }
             }
-            List<WarGearCombination> configurations = new List<WarGearCombination>();
-            configurations.AddRange(cp.WarGearCombinations);
-            foreach(WarGearCombination configuration in configurations)
+            Dictionary<string, WarGearCombination> uniques = new Dictionary<string, WarGearCombination>();
+            foreach (WarGearCombination configuration in cp.WarGearCombinations)
             {
-                var configs = cp.WarGearCombinations.Where(c => c.Weapons.Select(a => a.Id).OrderBy(id => id).SequenceEqual(configuration.Weapons.Select(a => a.Id).OrderBy(id => id))).Skip(1).ToList();
-                foreach(WarGearCombination c in configs)
-                    cp.WarGearCombinations.Remove(c);
+                var key = string.Join("_", configuration.Weapons.Select(a => a.Id).OrderBy(id => id));
+                uniques[key] = configuration;
             }
+            cp.WarGearCombinations = uniques.Values.ToList();
 
             var configSelected = cp.WarGearCombinations.Where(c => c.Selected);
             if (configSelected.Count() > 1 && configSelected.SelectMany(c => c.Weapons).Select(a => a.Id).Distinct().Count() == 1)


### PR DESCRIPTION
I think the bug reported in the KTRules repo here (https://github.com/KTManager/KTRules/issues/47), is related to deduplicating equipment loadouts.  This code refactors the LINQ queries into a simple iteration, using the immutable and hashable properties of strings as keys.

Please let me know if I misinterpreted the previous code

WIP because there are probably more places to optimize.. and also because I want to review this code tomorrow